### PR TITLE
fix: align DataFrame columns before merging in combine()

### DIFF
--- a/main.py
+++ b/main.py
@@ -174,11 +174,14 @@ def combine(symbol):
 
     file_name = symbol_to_file_name(symbol)
     prev = None
-    columns = None
+    # Define expected columns to ensure consistency
+    expected_columns = ['Open', 'High', 'Low', 'Close', 'Adj Close', 'Volume']
+    
     if Path(file_name).exists():
         prev = pd.read_csv(file_name, dtype=np.float64, index_col=["time"])
-        prev.index = prev.index.to_numpy(np.int64)
-        columns = list(prev.columns)
+        prev.index = prev.index.astype(np.int64)
+        # Align columns with expected_columns, filling missing with NaN
+        prev = prev.reindex(columns=expected_columns)
 
     start = datetime.datetime.now() - datetime.timedelta(days=28)
 
@@ -209,7 +212,9 @@ def combine(symbol):
             finally:
                 start = end
                 
+    # After downloading new data, align columns
     current = download(symbol)
+    current = current.reindex(columns=expected_columns)  # Ensure current has expected columns
 
     return merge(prev, current)
 


### PR DESCRIPTION
Ensure consistent column structure between existing and newly downloaded data by reindexing both DataFrames to expected columns. This resolves the ValueError caused by column mismatches after yfinance updates introduced new columns like 'Dividends' and 'Stock Splits'.

Changes:
- Define expected_columns to enforce consistent structure
- Reindex prev and current DataFrames to align columns
- Handle missing columns in older data by filling with NaN